### PR TITLE
blim012/multiple audio playing bug

### DIFF
--- a/AudioEngine/AudioEngine.cpp
+++ b/AudioEngine/AudioEngine.cpp
@@ -1,7 +1,7 @@
 #include "AudioEngine.h"
 
 
-FMOD_Handler::FMOD_Handler() 
+FMOD_Handler::FMOD_Handler()
 {
 	//_system = NULL;
 	//audioEngine::errorCheck(FMOD::System_Create(&_system));
@@ -33,20 +33,20 @@ FMOD_Handler *FMOD_Handler::instance()
 //Their keys correspond to the systemID
 void FMOD_Handler::addSystem(string systemID)
 {
-        auto mSystemIt = _mSystems.find(systemID);
-        if(mSystemIt == _mSystems.end())
-        {
-	        FMOD::System *newSystem = NULL;
-	        audioEngine::errorCheck(FMOD::System_Create(&newSystem));
-	        audioEngine::errorCheck(newSystem->init(512, FMOD_INIT_NORMAL, 0));
-	        _mSystems[systemID] = newSystem;
+	auto mSystemIt = _mSystems.find(systemID);
+	if (mSystemIt == _mSystems.end())
+	{
+		FMOD::System *newSystem = NULL;
+		audioEngine::errorCheck(FMOD::System_Create(&newSystem));
+		audioEngine::errorCheck(newSystem->init(512, FMOD_INIT_NORMAL, 0));
+		_mSystems[systemID] = newSystem;
 
-	        _ChannelMap newChannelMap;
-	        _dChannels[systemID] = newChannelMap;
+		_ChannelMap newChannelMap;
+		_dChannels[systemID] = newChannelMap;
 
-	        _SoundMap newSoundMap;
-	        _dSounds[systemID] = newSoundMap;
-        }
+		_SoundMap newSoundMap;
+		_dSounds[systemID] = newSoundMap;
+	}
 }
 
 //Removes system and all associated channels and sounds
@@ -82,7 +82,7 @@ void FMOD_Handler::update()
 {
 	vector<_ChannelMap::iterator> channelsToFree;
 
-	for (auto dirIt = _dChannels.begin(); dirIt!= _dChannels.end(); dirIt++)
+	for (auto dirIt = _dChannels.begin(); dirIt != _dChannels.end(); dirIt++)
 	{
 		for (auto mapIt = dirIt->second.begin(); mapIt != dirIt->second.end(); mapIt++)
 		{
@@ -182,7 +182,7 @@ void audioEngine::unloadSound(string systemID, const string &strSoundName)
 
 //The volume level should be sent in as decibels.
 //The typical decibel level of a normal conversation is 60dB, and a lawnmower is 90dB
-int audioEngine::aePlaySound(string systemID, const string& strSoundName, FMOD_VECTOR vec3, float fVolumedB)
+int audioEngine::aePlaySound(string systemID, const string& strSoundName, float fVolumedB)
 {
 	auto inst = FMOD_Handler::instance();
 	int channelID = inst->getNextChannelID();
@@ -210,22 +210,23 @@ int audioEngine::aePlaySound(string systemID, const string& strSoundName, FMOD_V
 		audioEngine::errorCheck(soundIt->second->getMode(&modeMask));
 
 		//Set 3d position if the sound has the 3D attribute
+		/*
 		if (modeMask & FMOD_3D)
 		{
 			audioEngine::errorCheck(playChannel->set3DAttributes(&vec3, nullptr));
 		}
-
+		*/
 		//setVolume expects a linear volume level, not dB.
 		audioEngine::errorCheck(playChannel->setVolume(dbToVolume(fVolumedB)));
 		audioEngine::errorCheck(playChannel->setPaused(false));
-		
+
 		inst->_dChannels[systemID][channelID] = playChannel;
 	}
 
 	return channelID;
 }
 
-void audioEngine::unloadChannel(string systemID, int channelID)
+void audioEngine::unloadChannel(string systemID, string strSoundName,  int channelID)
 {
 	auto inst = FMOD_Handler::instance();
 	auto dChannelIt = inst->_dChannels.find(systemID);
@@ -236,6 +237,7 @@ void audioEngine::unloadChannel(string systemID, int channelID)
 		{
 			audioEngine::errorCheck(mChannelIt->second->stop());
 			inst->_dChannels[systemID].erase(mChannelIt);
+			inst->_mAudioToChannel.erase(strSoundName);
 		}
 	}
 }
@@ -253,7 +255,7 @@ void audioEngine::unloadAllChannelsInSystem(string systemID)
 			errorCheck(mapIt->second->stop());
 			channelsToFree.push_back(mapIt);
 		}
-		
+
 		for (auto ctfIt = channelsToFree.begin(); ctfIt != channelsToFree.end(); ctfIt++)
 		{
 			dChannelIt->second.erase(*ctfIt);
@@ -354,7 +356,7 @@ float audioEngine::volumeTodb(float fVolumeLinear)
 void dspEngine::addDSPEffect(string systemID, FMOD_DSP_TYPE dspType)
 {
 	auto test = FMOD_Handler::instance();
-	if(!checkDSPInSystem(systemID, dspType))
+	if (!checkDSPInSystem(systemID, dspType))
 	{
 		auto inst = FMOD_Handler::instance();
 		auto systemsIt = inst->_mSystems.find(systemID);
@@ -442,7 +444,7 @@ void dspEngine::removeDSPEffect(string systemID, FMOD_DSP_TYPE dspType)
 void dspEngine::removeAllDSPEffectsInSystem(string systemID)
 {
 	auto inst = FMOD_Handler::instance();
-	
+
 	if (inst->_mDSP.count(systemID))
 	{
 		FMOD::ChannelGroup *master;
@@ -461,6 +463,29 @@ void dspEngine::removeAllDSPEffectsInSystem(string systemID)
 		{
 			inst->_mDSP.erase(*it);
 		}
+	}
+}
+
+void dspEngine::setEchoParameters(string systemID, FMOD_DSP_TYPE dspType, float delay, float feedback, float dry, float wet)
+{
+	FMOD::DSP *echo;
+	if (checkDSPInSystem(systemID, dspType, &echo))
+	{
+		echo->setParameterFloat(0, delay);
+		echo->setParameterFloat(1, feedback);
+		echo->setParameterFloat(2, dry);
+		echo->setParameterFloat(3, wet);
+	}
+}
+
+void dspEngine::setEqParameters(string systemID, FMOD_DSP_TYPE dspType, float lowgain, float midgain, float highgain)
+{
+	FMOD::DSP *eq;
+	if (checkDSPInSystem(systemID, dspType, &eq))
+	{
+		eq->setParameterFloat(0, lowgain);
+		eq->setParameterFloat(1, midgain);
+		eq->setParameterFloat(2, highgain);
 	}
 }
 
@@ -523,7 +548,6 @@ int main()
 	ae->setChannelVolume(n, id, 0);
 	ae->setPauseOnChannel(n, id, true);
 	ae->setPauseOnChannel(n, id, false);
-
 	while (1) { ae->update(); }
 	return 0;
 }

--- a/AudioEngine/AudioEngine.cpp
+++ b/AudioEngine/AudioEngine.cpp
@@ -90,7 +90,10 @@ void FMOD_Handler::update()
 			mapIt->second->isPlaying(&playing);
 			if (!playing)
 			{
-				channelsToFree.push_back(mapIt);
+			        string strSoundName = _mChannelToAudio[mapIt->first];
+				_mChannelToAudio.erase(mapIt->first);
+				_mAudioToChannel.erase(strSoundName);
+			        channelsToFree.push_back(mapIt);
 			}
 		}
 
@@ -226,7 +229,7 @@ int audioEngine::aePlaySound(string systemID, const string& strSoundName, float 
 	return channelID;
 }
 
-void audioEngine::unloadChannel(string systemID, string strSoundName,  int channelID)
+void audioEngine::unloadChannel(string systemID, int channelID)
 {
 	auto inst = FMOD_Handler::instance();
 	auto dChannelIt = inst->_dChannels.find(systemID);
@@ -237,6 +240,8 @@ void audioEngine::unloadChannel(string systemID, string strSoundName,  int chann
 		{
 			audioEngine::errorCheck(mChannelIt->second->stop());
 			inst->_dChannels[systemID].erase(mChannelIt);
+			string strSoundName = inst->_mChannelToAudio[channelID];
+			inst->_mChannelToAudio.erase(channelID);
 			inst->_mAudioToChannel.erase(strSoundName);
 		}
 	}
@@ -260,6 +265,9 @@ void audioEngine::unloadAllChannelsInSystem(string systemID)
 		{
 			dChannelIt->second.erase(*ctfIt);
 		}
+
+		inst->_mAudioToChannel.clear();
+		inst->_mChannelToAudio.clear();
 	}
 }
 

--- a/AudioEngine/AudioEngine.h
+++ b/AudioEngine/AudioEngine.h
@@ -36,13 +36,15 @@ public:
 													    //right: Map of channels for a given system
 
 	typedef map<string, int> _AudioToChannel;           //maps the audio file name to the channel it is playing on
-
+        typedef map<int, string> _ChannelToAudio;
+  
 	typedef multimap<string, FMOD::DSP*> _dspMap; //Container for DSP effects in a system
 												  //Distinguish between the DSP effects by searching with DSP::getType
 
 	_SystemMap _mSystems;
 	_ChannelDirectory _dChannels;
 	_AudioToChannel _mAudioToChannel;
+        _ChannelToAudio _mChannelToAudio;
 	_SoundDirectory _dSounds;
 	_dspMap _mDSP;
 	
@@ -71,7 +73,7 @@ public:
 	void loadSound(string systemID, const string& strSoundName, bool b3d = true, bool bLooping = false, bool bStream = false);
 	void unloadSound(string systemID, const string& strSoundName);
 	int aePlaySound(string systemID, const string& strSoundName, float fVolumedB = 0.0f); //Distinct from FMOD_Channel's playSound
-	void unloadChannel(string systemID, string strSoundName, int channelID); //Can also be used to preemptively stop sound from a channel
+	void unloadChannel(string systemID, int channelID); //Can also be used to preemptively stop sound from a channel
 	void unloadAllChannelsInSystem(string systemID); //Unload channels in a GIVEN system, not in ALL systems
 	void togglePauseOnChannel(string systemID, int channelID);
 	void setPauseOnChannel(string systemID, int channelID, bool pause);

--- a/AudioEngine/AudioEngine.h
+++ b/AudioEngine/AudioEngine.h
@@ -35,14 +35,14 @@ public:
 	typedef map<string, _ChannelMap> _ChannelDirectory; //left: System the ChannelMap is set to
 													    //right: Map of channels for a given system
 
-        typedef map<string, int> _AudioToChannel;                 //Maps the audio file name to the channel it is playing on
-  
+	typedef map<string, int> _AudioToChannel;           //maps the audio file name to the channel it is playing on
+
 	typedef multimap<string, FMOD::DSP*> _dspMap; //Container for DSP effects in a system
 												  //Distinguish between the DSP effects by searching with DSP::getType
 
 	_SystemMap _mSystems;
 	_ChannelDirectory _dChannels;
-        _AudioToChannel _mAudioToChannel;
+	_AudioToChannel _mAudioToChannel;
 	_SoundDirectory _dSounds;
 	_dspMap _mDSP;
 	
@@ -70,8 +70,8 @@ public:
 
 	void loadSound(string systemID, const string& strSoundName, bool b3d = true, bool bLooping = false, bool bStream = false);
 	void unloadSound(string systemID, const string& strSoundName);
-	int aePlaySound(string systemID, const string& strSoundName, FMOD_VECTOR vec3 = FMOD_VECTOR{ 0, 0, 0 }, float fVolumedB = 0.0f); //Distinct from FMOD_Channel's playSound
-	void unloadChannel(string systemID, int channelID); //Can also be used to preemptively stop sound from a channel
+	int aePlaySound(string systemID, const string& strSoundName, float fVolumedB = 0.0f); //Distinct from FMOD_Channel's playSound
+	void unloadChannel(string systemID, string strSoundName, int channelID); //Can also be used to preemptively stop sound from a channel
 	void unloadAllChannelsInSystem(string systemID); //Unload channels in a GIVEN system, not in ALL systems
 	void togglePauseOnChannel(string systemID, int channelID);
 	void setPauseOnChannel(string systemID, int channelID, bool pause);
@@ -90,7 +90,8 @@ public:
 	void stopAllDSPEffectsInSystem(string systemID);
 	void removeDSPEffect(string systemID, FMOD_DSP_TYPE dspType);
 	void removeAllDSPEffectsInSystem(string systemID);
-
+	void setEchoParameters(string systemID, FMOD_DSP_TYPE dspType, float delay, float feedback, float dry, float wet);
+	void setEqParameters(string systemID, FMOD_DSP_TYPE dspType, float lowgain, float midgain, float highgain);
 
 private:
 	inline bool checkIndex(int index, int limit);

--- a/AudioEngine/FMOD_tests.cpp
+++ b/AudioEngine/FMOD_tests.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Create Channel via aePlaySound and unload channels", "[FMOD::System::
 	REQUIRE(mChannelIt2 != inst->_dChannels["Test aePlaySound"].end());
 	REQUIRE(mChannelIt3 != inst->_dChannels["Test aePlaySound"].end());
 	
-	a->unloadChannel("Test aePlaySound", "audio/jaguar.wav", channel1);
+	a->unloadChannel("Test aePlaySound", channel1);
 	mChannelIt1 = inst->_dChannels["Test aePlaySound"].find(channel1);
 	REQUIRE(mChannelIt1 == inst->_dChannels["Test aePlaySound"].end());
 

--- a/AudioEngine/PacketParser.cpp
+++ b/AudioEngine/PacketParser.cpp
@@ -202,7 +202,9 @@ void packetParser::parseData(string packet)
 
 void packetParser::applyRequest()
 {
-	auto inst = FMOD_Handler::instance();
+        update(); //TODO: Should be moved out of this function, once process forking is implemented
+
+        auto inst = FMOD_Handler::instance();
 	auto d = dspEngine();
 	int channelID;
 	addSystem("mainSystem");
@@ -213,7 +215,7 @@ void packetParser::applyRequest()
 		auto channel = inst->_mAudioToChannel.find(request.filename);
 		if (channel != inst->_mAudioToChannel.end())
 		{
-			unloadChannel("mainSystem", request.filename, channel->second);
+			unloadChannel("mainSystem",  channel->second);
 			unloadSound("mainSystem", request.filename);
 		}
 	}
@@ -223,8 +225,10 @@ void packetParser::applyRequest()
 		{
 			if (atcIt == inst->_mAudioToChannel.end())
 			{
+			        unloadAllChannelsInSystem("mainSystem");
 				channelID = aePlaySound("mainSystem", request.filename);
 				inst->_mAudioToChannel[request.filename] = channelID;
+				inst->_mChannelToAudio[channelID] = request.filename;
 				atcIt = inst->_mAudioToChannel.find(request.filename);
 			}
 			else

--- a/AudioEngine/PacketParser.cpp
+++ b/AudioEngine/PacketParser.cpp
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_WARNINGS
 #include "PacketParser.h"
 #include <stdio.h>
 #include <cstring>
@@ -8,7 +9,6 @@ void packetParser::parseData(string packet)
 {
 	request.usernames.clear();
 
-	char *strtokState;
 	char *packetChar = new char[packet.size() + 1];
 	strncpy(packetChar, packet.c_str(), packet.size() + 1);
 	const char *delim = "{}[]\':,\"";
@@ -17,7 +17,7 @@ void packetParser::parseData(string packet)
 	string dir = "audio/";
 	char *prefix = new char[dir.size() + packet.size() + 1];
 	strncpy(prefix, "audio/", dir.size() + packet.size() + 1);
-        
+
 	vector<char *> packetData;
 	while (token)
 	{
@@ -25,6 +25,11 @@ void packetParser::parseData(string packet)
 		token = strtok(NULL, delim/*, &strtokState*/);
 	}
 
+	for(int i = 0; i < packetData.size(); i++)
+	  {
+	    printf("%s\n", packetData[i]);
+	  } 
+	
 	for (auto it = packetData.begin(); it != packetData.end(); it++)
 	{
 		if (strcmp(*it, "userID") == 0)
@@ -39,7 +44,7 @@ void packetParser::parseData(string packet)
 			if (it + 1 != packetData.end() && strcmp(*(it + 1), "userID") != 0)
 			{
 				strncat(prefix, *(it + 2), dir.size() + packet.size() + 1);
-        			request.filename = prefix; 
+				request.filename = prefix;
 			}
 		}
 		else if (strcmp(*it, "play") == 0)
@@ -56,79 +61,215 @@ void packetParser::parseData(string packet)
 				}
 			}
 		}
+		else if (strcmp(*it, "stop") == 0)
+		{
+			if (it + 1 != packetData.end())
+			{
+				if (strcmp(*(it + 2), "true") == 0)
+				{
+					request.stop = true;
+				}
+				else if (strcmp(*(it + 2), "false") == 0)
+				{
+					request.stop = false;
+				}
+			}
+		}
 		else if (strcmp(*it, "volume") == 0)
 		{
 			if (it + 1 != packetData.end())
 			{
-                                // this is throwing an exception
+				// this is throwing an exception
 				request.volume = stof(*(it + 2));
-//                                cout << "error parsing volume, stof throwing exception\n";
+				// cout << "error parsing volume, stof throwing exception\n";
+			}
+		}
+		else if (strcmp(*it, "echo") == 0)
+		{
+			if (it + 1 != packetData.end())
+			{
+				if (strcmp(*(it + 2), "apply") == 0)
+				{
+					if (strcmp(*(it + 4), "true") == 0)
+					{
+						request.echo.apply = true;
+					}
+					else if (strcmp(*(it + 4), "false") == 0)
+					{
+						request.echo.apply = false;
+					}
+				}
+				if (strcmp(*(it + 6), "delay") == 0)
+				{
+					request.echo.delay = stof(*(it + 8));
+				}
+				if (strcmp(*(it + 10), "feedback") == 0)
+				{
+				  request.echo.feedback = stof(*(it + 12));
+				}
+				if (strcmp(*(it + 14), "dry") == 0)
+				{
+					request.echo.dry = stof(*(it + 16));
+				}
+				if (strcmp(*(it + 18), "wet") == 0)
+				{
+					request.echo.wet = stof(*(it + 20));
+				}
+			}
+		}
+		else if (strcmp(*it, "equalizer") == 0)
+		{
+			if (it + 1 != packetData.end())
+			{
+				if (strcmp(*(it + 2), "apply") == 0)
+				{
+					if (strcmp(*(it + 4), "true") == 0)
+					{
+						request.eq.apply = true;
+					}
+					else if (strcmp(*(it + 4), "false") == 0)
+					{
+						request.eq.apply = false;
+					}
+				}
+				if (strcmp(*(it + 6), "lowgain") == 0)
+				{
+					request.eq.lowgain = stof(*(it + 8));
+				}
+				if (strcmp(*(it + 10), "midgain") == 0)
+				{
+					request.eq.midgain = stof(*(it + 12));
+				}
+				if (strcmp(*(it + 14), "highgain") == 0)
+				{
+					request.eq.highgain = stof(*(it + 16));
+				}
 			}
 		}
 	}
-/*	
+	
 	for (auto it = request.usernames.begin(); it != request.usernames.end(); it++)
 	{
-		//printf(*it);
-		//printf("\n");
+		printf(*it);
+		printf("\n");
 	}
-	//printf("%s", request.filename);
-	//printf("\n");
+	printf("%s", request.filename);
+	printf("\n");
 	if (request.play)
 	{
-		printf("true\n");
+		printf("play: true\n");
 	}
 	else
 	{
-		printf("false\n");
+		printf("play: false\n");
 	}
-	printf("%f", request.volume);
-*/
+	if (request.stop)
+	{
+		printf("stop: true\n");
+	}
+	else
+	{
+		printf("stop: false\n");
+	}
+	printf("%f\n", request.volume);
+	printf("echo: \n");
+	if (request.echo.apply)
+	{
+		printf("apply == true\n");
+	}
+	else
+	{
+		printf("apply == false\n");
+	}
+	printf("%f\n", request.echo.delay);
+	printf("%f\n", request.echo.feedback);
+	printf("%f\n", request.echo.dry);
+	printf("%f\n", request.echo.wet);
+	printf("equalizer: \n");
+	if (request.eq.apply)
+	{
+		printf("apply == true\n");
+	}
+	else
+	{
+		printf("apply == false\n");
+	}
+	printf("%f\n", request.eq.lowgain);
+	printf("%f\n", request.eq.midgain);
+	printf("%f\n", request.eq.highgain);
 	
 }
 
 void packetParser::applyRequest()
 {
 	auto inst = FMOD_Handler::instance();
+	auto d = dspEngine();
 	int channelID;
 	addSystem("mainSystem");
 
-	//Potential bug:
-	//If the same audio file is passed in again, its channel it is playing on will still be here
 	auto atcIt = inst->_mAudioToChannel.find(request.filename);
-	if (request.play)
+	if (request.stop == true)
 	{
-		if (atcIt == inst->_mAudioToChannel.end())
+		auto channel = inst->_mAudioToChannel.find(request.filename);
+		if (channel != inst->_mAudioToChannel.end())
 		{
-			channelID = aePlaySound("mainSystem", request.filename); //error here
-			inst->_mAudioToChannel[request.filename] = channelID;
-			atcIt = inst->_mAudioToChannel.find(request.filename);
-		}
-		else
-		{
-			setPauseOnChannel("mainSystem", atcIt->second, false);
+			unloadChannel("mainSystem", request.filename, channel->second);
+			unloadSound("mainSystem", request.filename);
 		}
 	}
-	else //request.play == false
+	else
 	{
-		if (atcIt == inst->_mAudioToChannel.end())
+		if (request.play)
 		{
-			loadSound("mainSystem", request.filename);
+			if (atcIt == inst->_mAudioToChannel.end())
+			{
+				channelID = aePlaySound("mainSystem", request.filename);
+				inst->_mAudioToChannel[request.filename] = channelID;
+				atcIt = inst->_mAudioToChannel.find(request.filename);
+			}
+			else
+			{
+				setPauseOnChannel("mainSystem", atcIt->second, false);
+			}
 		}
-		else
+		else //request.play == false
 		{
-			setPauseOnChannel("mainSystem", atcIt->second, true);
+			if (atcIt == inst->_mAudioToChannel.end())
+			{
+				loadSound("mainSystem", request.filename);
+			}
+			else
+			{
+				setPauseOnChannel("mainSystem", atcIt->second, true);
+			}
 		}
-	}
 
-	if (request.volume != 0.0)
-	{
-		if (atcIt != inst->_mAudioToChannel.end())
+		if (request.volume != 0.0)
 		{
-			setChannelVolume("mainSystem", atcIt->second, request.volume);
+			if (atcIt != inst->_mAudioToChannel.end())
+			{
+				setChannelVolume("mainSystem", atcIt->second, request.volume);
+			}
+		}
+
+		if (request.echo.apply == true)
+		{
+			d.addDSPEffect("mainSystem", FMOD_DSP_TYPE_ECHO);
+			d.setEchoParameters("mainSystem", FMOD_DSP_TYPE_ECHO, request.echo.delay, request.echo.feedback, request.echo.dry, request.echo.wet);
+		}
+		else
+		{
+			d.removeDSPEffect("mainSystem", FMOD_DSP_TYPE_ECHO);
+		}
+
+		if (request.eq.apply == true)
+		{
+			d.addDSPEffect("mainSystem", FMOD_DSP_TYPE_THREE_EQ);
+			d.setEqParameters("mainSystem", FMOD_DSP_TYPE_THREE_EQ, request.eq.lowgain, request.eq.midgain, request.eq.highgain);
+		}
+		else
+		{
+			d.removeDSPEffect("mainSystem", FMOD_DSP_TYPE_THREE_EQ);
 		}
 	}
 }
-
-
-

--- a/AudioEngine/PacketParser.h
+++ b/AudioEngine/PacketParser.h
@@ -6,13 +6,32 @@
 
 using namespace std;
 
-//Should make it so that addSystem in AudioEngine will not make a system if one of the same name already exists
+struct echoEffect
+{
+	bool apply;
+	float delay;
+	float feedback;
+	float dry;
+	float wet;
+};
+
+struct eqEffect
+{
+	bool apply;
+	float lowgain;
+	float midgain;
+	float highgain;
+};
+
 struct dataPacket
 {
 	vector<char*> usernames;
 	char *filename;
 	bool play;
+	bool stop;
 	float volume;
+	echoEffect echo;
+	eqEffect eq;
 };
 
 class packetParser : public audioEngine
@@ -28,6 +47,37 @@ private:
 
 /*
 
+New packet syntax:
+let packet = {
+  group: [
+	{ userID: "" },
+	{ userID: "" },
+	{ userID: "" },
+	{ userID: "" },
+	{ userID: "" },
+  ],
+  filename: "",
+  play: false,
+  stop: false,
+  parameters: {
+	volume: 0.0,
+	echo: {
+	  apply: false,
+	  delay: 10.0,
+	  feedback: 0.0,
+	  dry: 0.0,
+	  wet: 0.0
+	},
+	equalizer: {
+	  apply: false,
+	  lowgain: 0.0,
+	  midgain: 0.0,
+	  highgain: 0.0
+	}
+  }
+};
+
+Old packet syntax:
 {
   group: [
 	{ userID: "" },


### PR DESCRIPTION
Fixed the audio stacking bug, and audio files that have finished playing have their audio channels removed successfully along with their associated AudioToChannel and ChannelToAudio map entries. 